### PR TITLE
2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,13 @@
 {
   "name": "figma-plugin-react-hooks",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "figma-plugin-react-hooks",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "license": "MIT",
-      "dependencies": {
-        "figma-plugin-api": "^1.0.1"
-      },
       "devDependencies": {
         "@figma/plugin-typings": "*",
         "@types/react": "^18.2.48",
@@ -32,6 +29,7 @@
         "typescript": "^5.2.2"
       },
       "peerDependencies": {
+        "figma-plugin-api": ">=1.1.0",
         "react": ">=17.0.0"
       }
     },
@@ -2435,9 +2433,10 @@
       }
     },
     "node_modules/figma-plugin-api": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/figma-plugin-api/-/figma-plugin-api-1.0.1.tgz",
-      "integrity": "sha512-0u2p/fuBRbH3EZ2wlLgNsKn/3nTwFVT/E9796xLnKlTykZoDCrTvH7KZf7PuRoBWmGrvLAf9sZQZb7Whgv4Phg=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/figma-plugin-api/-/figma-plugin-api-1.1.0.tgz",
+      "integrity": "sha512-gk6LZMaKENPhf7efAdy/5VESX5HBhVirgJnnnsE9nwgNZKmYUj37sbZ1dDrtI6vxPvC/nUTr6nzBAYYWBd5x2g==",
+      "peer": true
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "figma-plugin-react-hooks",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "",
   "exports": {
     ".": {
@@ -32,10 +32,10 @@
     "start": "npm run dev",
     "build": "rm -rf lib/* && npm run build:index:common && npm run build:index:esm && npm run build:hook:common && npm run build:hook:esm && npm run build:types && npm run build:docs",
     "dev": "concurrently -n index-cjs,index-esm,hook-cjs,hook-esm,ts 'npm run build:index:common -- --watch' 'npm run build:index:esm -- --watch' 'npm run build:hook:common -- --watch' 'npm run build:hook:esm -- --watch' 'npm run build:types -- --watch'",
-    "build:index": "esbuild src/index.ts --target=es2017 --sourcemap --bundle",
+    "build:index": "esbuild src/index.ts --target=es2017 --sourcemap --bundle --external:figma-plugin-api",
     "build:index:common": "npm run build:index -- --format=cjs --outfile=lib/index.cjs",
     "build:index:esm": "npm run build:index -- --format=esm --outfile=lib/index.mjs",
-    "build:hook": "esbuild src/hook.ts --target=es2017 --sourcemap --bundle --external:react",
+    "build:hook": "esbuild src/hook.ts --target=es2017 --sourcemap --bundle --external:react --external:figma-plugin-api",
     "build:hook:common": "npm run build:hook -- --format=cjs --outfile=lib/hook.cjs",
     "build:hook:esm": "npm run build:hook -- --format=esm --outfile=lib/hook.mjs",
     "build:types": "tsc --emitDeclarationOnly --declaration --preserveWatchOutput",
@@ -46,10 +46,8 @@
   "author": "Mika Kuitunen",
   "license": "MIT",
   "peerDependencies": {
-    "react": ">=17.0.0"
-  },
-  "dependencies": {
-    "figma-plugin-api": "^1.0.1"
+    "react": ">=17.0.0",
+    "figma-plugin-api": ">=1.1.0"
   },
   "devDependencies": {
     "@figma/plugin-typings": "*",

--- a/src/hook.ts
+++ b/src/hook.ts
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 
 import useMountedEffect from './useMountedEffect';
 
-import { api, listeners, setlisteners } from '.';
+import { api, listeners, setlisteners, updateApiWithOptions, updateUiApiWithOptions } from '.';
 
 import {
   BareNode,
@@ -40,7 +40,6 @@ const useFigmaSelection = <const Options extends FigmaSelectionHookOptions>(
   }, [hookOptions]);
 
   useEffect(() => {
-    console.log('Hook mount');
     const mount = async () => {
       // Typing the listeners  explicitly is difficult due to the architecture, so we have to assert
       listeners.push(setSelection as unknown as FigmaSelectionListener);
@@ -48,6 +47,10 @@ const useFigmaSelection = <const Options extends FigmaSelectionHookOptions>(
       // if it's the first listener, register for selection change
       if (listeners.length === 1) {
         try {
+          if (opts.apiOptions) {
+            updateApiWithOptions(opts.apiOptions);
+            updateUiApiWithOptions(opts.apiOptions);
+          }
           await api._registerForSelectionChange(opts);
         } catch (e) {
           console.error(e);


### PR DESCRIPTION
## Breaking changes

- `figma-plugin-api` is now listed as a peer dependency and not bundled with the library. This ensures the hooks API works when other APIs using `figma-plugin-api` are also present.

## Fixes

- The hook updates the APIs with `apiOptions` if given (Resolves #2)