### PR TITLE
3.0.0

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -43,7 +43,7 @@
             "position": "before"
           },
           {
-            "pattern": "{.,..,../..}/**/types",
+            "pattern": "{.,..,../..}/**/type{s,Primitives}",
             "group": "type",
             "position": "after"
           }

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ const SomeComponent: FC = () => {
 export default SomeComponent;
 ```
 
-## Configuring the hook
+## Hook options
 
 The hook can be configured by passing an options object to the hook call.
 
@@ -51,9 +51,10 @@ constants.ts:
 ```typescript
 import { FigmaSelectionHookOptions } from 'figma-plugin-react-hooks/hook';
 
-export const selectionHookOptions: FigmaSelectionHookOptions = {
+// Using satisfies gives you type hints and autocomplete while retaining the exact inferred return type from the hook
+export const selectionHookOptions = {
   resolveChildrenNodes: true
-};
+} satisfies FigmaSelectionHookOptions;
 ```
 
 React app:
@@ -70,8 +71,27 @@ const SomeComponent: FC = () => {
 
   ...
 };
+```
 
-export default SomeComponent;
+### Types with custom options
+
+The library also exports a few utility types for you to use in your React components:
+
+```typescript
+import { FC } from 'react';
+
+import { FigmaSelectionHookNode } from 'figma-plugin-react-hooks/hook';
+
+import { figmaSelectionHookOptions } from './constants';
+
+// FigmaSelectionHookNode is the type of a single node returned from the hook, inferred from the options you pass to it
+interface NodeListItemProps {
+  node: FigmaSelectionHookNode<typeof figmaSelectionHookOptions>;
+}
+
+const NodeListItem: FC<NodeListItemProps> = ({ node }) => {
+  ...
+};
 ```
 
 ## Types
@@ -97,6 +117,18 @@ ___
 
 ___
 
+### BoundVariableKey
+
+Ƭ **BoundVariableKey**: keyof `NonNullable`\<`SceneNode`[``"boundVariables"``]\>
+
+___
+
+### OptSceneNodeVariables
+
+Ƭ **OptSceneNodeVariables**: readonly [`BoundVariableKey`](types.md#boundvariablekey)[] \| ``"all"``
+
+___
+
 ### FigmaSelectionHookOptions
 
 Ƭ **FigmaSelectionHookOptions**: `Object`
@@ -110,7 +142,7 @@ Example:
 ```typescript
 const options = {
   nodeTypes: ['TEXT', 'FRAME'],
-  resolveProperties: ['name', 'characters', 'children]
+  resolveProperties: ['name', 'characters', 'children']
 } satisfies FigmaSelectionHookOptions;
 ```
 
@@ -120,10 +152,38 @@ const options = {
 | :------ | :------ | :------ |
 | `nodeTypes?` | readonly `SceneNodeType`[] | Only return specific types of nodes. If left undefined, all nodes in the selection will be returned. Default: `undefined` |
 | `resolveProperties?` | [`OptSceneNodeProperties`](types.md#optscenenodeproperties) | Figma node properties are lazy-loaded, so to use any property you have to resolve it first. Resolving all node properties causes a performance hit, so you can specify which properties you want to resolve. If set to `[]`, no properties will be resolved and you will only get the ids of the nodes. Node methods (such as `getPluginData`) will never be resolved. Default: `'all'` |
-| `resolveChildren?` | `boolean` | Resolve children nodes of the selection. If used with `nodeTypes`, all nodes of the specified types will be returned as a flat array. Default: `false` |
-| `resolveVariables?` | `boolean` | Resolve bound variables of the selection. Default: `false` |
+| `resolveVariables?` | [`OptSceneNodeVariables`](types.md#optscenenodevariables) | Resolve bound variables of the selection. Similarly to `resolveProperties`, you can specify which variables you want to resolve to optimize performance. If set to `[]`, no properties will be resolved and you will only get the ids of the nodes. Default: `[]` |
+| `resolveChildren?` | `boolean` | Resolve children nodes of the selection. If `nodeTypes` is set, all nodes of the specified types will be returned as a flat array. Default: `false` |
 | `addAncestorsVisibleProperty?` | `boolean` | Add `ancestorsVisible` property to all nodes. This property is true if all ancestors of the node are visible. Default: `false` |
 | `apiOptions?` | [`RPCOptions`](types.md#rpcoptions) | Options for figma-plugin-api Default: see the RPCOptions type |
+
+___
+
+### FigmaSelectionHookNode
+
+Ƭ **FigmaSelectionHookNode**\<`Options`\>: `SerializedResolvedNode`\<`CombineObjects`\<typeof `DEFAULT_HOOK_OPTIONS`, `Options`\>\>
+
+Utility type to get the inferred type of the hook using the options object
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `Options` | extends [`FigmaSelectionHookOptions`](types.md#figmaselectionhookoptions) = `Record`\<`string`, `never`\> |
+
+___
+
+### FigmaSelectionHookType
+
+Ƭ **FigmaSelectionHookType**\<`Options`\>: [readonly [`FigmaSelectionHookNode`](types.md#figmaselectionhooknode)\<`Options`\>[], (`selection`: readonly `BareNode`[]) => `void`]
+
+Utility type to get the inferred return type of the hook using the options object
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `Options` | extends [`FigmaSelectionHookOptions`](types.md#figmaselectionhookoptions) = `Record`\<`string`, `never`\> |
 
 ## Variables
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,7 +36,7 @@ const SomeComponent: FC = () => {
 export default SomeComponent;
 ```
 
-## Configuring the hook
+## Hook options
 
 The hook can be configured by passing an options object to the hook call.
 
@@ -49,9 +49,10 @@ constants.ts:
 ```typescript
 import { FigmaSelectionHookOptions } from 'figma-plugin-react-hooks/hook';
 
-export const selectionHookOptions: FigmaSelectionHookOptions = {
+// Using satisfies gives you type hints and autocomplete while retaining the exact inferred return type from the hook
+export const selectionHookOptions = {
   resolveChildrenNodes: true
-};
+} satisfies FigmaSelectionHookOptions;
 ```
 
 React app:
@@ -68,6 +69,25 @@ const SomeComponent: FC = () => {
 
   ...
 };
+```
 
-export default SomeComponent;
+### Types with custom options
+
+The library also exports a few utility types for you to use in your React components:
+
+```typescript
+import { FC } from 'react';
+
+import { FigmaSelectionHookNode } from 'figma-plugin-react-hooks/hook';
+
+import { figmaSelectionHookOptions } from './constants';
+
+// FigmaSelectionHookNode is the type of a single node returned from the hook, inferred from the options you pass to it
+interface NodeListItemProps {
+  node: FigmaSelectionHookNode<typeof figmaSelectionHookOptions>;
+}
+
+const NodeListItem: FC<NodeListItemProps> = ({ node }) => {
+  ...
+};
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "figma-plugin-react-hooks",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "figma-plugin-react-hooks",
-      "version": "2.0.1",
+      "version": "3.0.0",
       "license": "MIT",
       "devDependencies": {
         "@figma/plugin-typings": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "figma-plugin-react-hooks",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "description": "",
   "exports": {
     ".": {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,17 @@
+import { ResolverOptions } from './types';
+
 /**
  *  Used to replace `figma.mixed` during JSON serialization
  */
 export const FIGMA_MIXED = 'mixed-57999e63-7384-42a1-acf8-d80b9f6c36a7';
+
+/**
+ * Default options for the hook
+ */
+export const DEFAULT_HOOK_OPTIONS = {
+  nodeTypes: undefined,
+  resolveChildren: false,
+  resolveVariables: [],
+  resolveProperties: 'all',
+  addAncestorsVisibleProperty: false
+} as const satisfies ResolverOptions;

--- a/src/hook.ts
+++ b/src/hook.ts
@@ -2,38 +2,33 @@
 
 import { useEffect, useState } from 'react';
 
+import { DEFAULT_HOOK_OPTIONS } from './constants';
 import useMountedEffect from './useMountedEffect';
 
 import { api, listeners, setlisteners, updateApiWithOptions, updateUiApiWithOptions } from '.';
 
+import { CombineObjects } from './typePrimitives';
 import {
-  BareNode,
   FigmaSelectionHookOptions,
   FigmaSelectionListener,
-  ResolverOptions,
-  SerializedResolvedNode
+  SerializedResolvedNode,
+  FigmaSelectionHookType
 } from './types';
 
-export { FigmaSelectionHookOptions } from './types';
+export { FigmaSelectionHookOptions, FigmaSelectionHookNode, FigmaSelectionHookType } from './types';
 export { FIGMA_MIXED } from './constants';
-
-const defaultOptions = {
-  nodeTypes: undefined,
-  resolveChildren: false,
-  resolveVariables: false,
-  resolveProperties: 'all',
-  addAncestorsVisibleProperty: false
-} as const satisfies ResolverOptions;
 
 /**
  * Only one config will take presence and it will be the config of the first hook that is mounted
  */
 const useFigmaSelection = <const Options extends FigmaSelectionHookOptions>(
   hookOptions?: Options
-): [readonly SerializedResolvedNode<Options>[], (selection: readonly BareNode[]) => void] => {
-  const opts = { ...defaultOptions, ...hookOptions } as const;
+): FigmaSelectionHookType<Options> => {
+  const opts = { ...DEFAULT_HOOK_OPTIONS, ...hookOptions } as const;
 
-  const [selection, setSelection] = useState<readonly SerializedResolvedNode<Options>[]>([]);
+  const [selection, setSelection] = useState<
+    readonly SerializedResolvedNode<CombineObjects<typeof DEFAULT_HOOK_OPTIONS, Options>>[]
+  >([]);
 
   useMountedEffect(() => {
     console.warn('useFigmaSelection: changing options once mounted will not affect the behavior of the hook');
@@ -70,7 +65,10 @@ const useFigmaSelection = <const Options extends FigmaSelectionHookOptions>(
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  return [selection as readonly SerializedResolvedNode<Options>[], api._setSelection];
+  return [
+    selection as readonly SerializedResolvedNode<CombineObjects<typeof DEFAULT_HOOK_OPTIONS, Options>>[],
+    api._setSelection
+  ];
 };
 
 export default useFigmaSelection;

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,7 +76,7 @@ const documentChangeHandler = (e: DocumentChangeEvent) => {
 };
 
 const apiMethods = {
-  _registerForSelectionChange(opts: FigmaSelectionHookOptions) {
+  _registerForSelectionChange(opts: ResolverOptions & FigmaSelectionHookOptions) {
     options = opts;
 
     const apiOptions = opts.apiOptions;
@@ -104,7 +104,7 @@ export const updateApiWithOptions = (rpcOptions: RPCOptions) => {
   api = createPluginAPI(apiMethods, rpcOptions);
 };
 
-let options: FigmaSelectionHookOptions;
+let options: ResolverOptions & FigmaSelectionHookOptions;
 
 export let listeners: FigmaSelectionListener[] = [];
 

--- a/src/typePrimitives.ts
+++ b/src/typePrimitives.ts
@@ -1,13 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-types */
 
-/**
- * @internal
- * https://github.com/microsoft/TypeScript/issues/17002#issuecomment-1529056512
- */
-export type ArrayType<T> = Extract<
-  true extends T & false ? unknown[] : T extends readonly unknown[] ? T : unknown[],
-  T
->;
+export type Mutable<T> = { -readonly [P in keyof T]: T[P] };
 
 /**
  * @internal
@@ -42,3 +35,20 @@ export type ApplicableNonFunctionPropertyKeys<T extends object, K extends string
     ? never
     : K
   : never;
+
+export type ExtractProps<T extends object, P, K extends keyof T = keyof T> = Pick<
+  T,
+  K extends keyof T ? (T[K] extends P ? K : never) : never
+>;
+
+export type CombineObjects<A extends object, B extends object> = {
+  [K in keyof A | keyof B]: K extends keyof B
+    ? B[K] extends undefined
+      ? K extends keyof A
+        ? A[K]
+        : never
+      : NonNullable<B[K]>
+    : K extends keyof A
+      ? A[K]
+      : never;
+};

--- a/src/typeUtils.ts
+++ b/src/typeUtils.ts
@@ -1,4 +1,4 @@
-import { ArrayType } from './typePrimitives';
+type ArrayType<T> = Extract<true extends T & false ? unknown[] : T extends readonly unknown[] ? T : unknown[], T>;
 
 export const isArray = Array.isArray as <T>(arg: T) => arg is ArrayType<T>;
 

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -2,9 +2,20 @@
 
 import { expectType } from 'tsd';
 
-import { ApplicableNonFunctionPropertyKeys, NonFunctionPropertyKeys } from '../src/typePrimitives';
-
-import { BareNode, SerializedNode, SerializedResolvedNode, SceneNodeFromTypes } from '../src/types';
+import {
+  ApplicableNonFunctionPropertyKeys,
+  CombineObjects,
+  ExtractProps,
+  NonFunctionPropertyKeys
+} from '../src/typePrimitives';
+import {
+  BareNode,
+  SerializedNode,
+  SerializedResolvedNode,
+  SceneNodeFromTypes,
+  BoundVariables,
+  BoundVariableInstances
+} from '../src/types';
 
 // NonFunctionPropertyKeys should return all property keys of an object that are not functions
 expectType<'id' | 'type'>({} as NonFunctionPropertyKeys<{ id: 'asd'; type: 'asd'; getType: () => 'asd' }>);
@@ -37,7 +48,7 @@ expectType<
       nodeTypes: ['TEXT'];
       resolveProperties: ['characters'];
       resolveChildren: false;
-      resolveVariables: false;
+      resolveVariables: [];
       addAncestorsVisibleProperty: false;
     }
   >
@@ -56,7 +67,7 @@ expectType<
     nodeTypes: ['TEXT'];
     resolveProperties: ['characters'];
     resolveChildren: false;
-    resolveVariables: false;
+    resolveVariables: [];
     addAncestorsVisibleProperty: false;
   }>
 );
@@ -80,7 +91,24 @@ expectType<
     nodeTypes: ['TEXT', 'FRAME'];
     resolveProperties: ['characters', 'children'];
     resolveChildren: false;
-    resolveVariables: false;
+    resolveVariables: [];
     addAncestorsVisibleProperty: false;
   }>
 );
+
+// keyof BoundVariables and keyof BoundVariableInstances should be the same
+expectType<keyof BoundVariables>('' as keyof BoundVariableInstances);
+
+// ExtractProps should return the properties that match the given type
+expectType<{
+  c: 'asd';
+  d: 'asd';
+}>({} as ExtractProps<{ a: 1; b: [1, 2]; c: 'asd'; d: 'asd' }, string>);
+
+// CombineObjects should merge the properties of two objects, using non-undefined properties from the second object
+expectType<{
+  a: number;
+  b: number;
+  c: boolean;
+  d: string;
+}>({} as CombineObjects<{ a: string; b: number; d: string }, { a?: number; b: undefined; c: boolean }>);


### PR DESCRIPTION
## Breaking changes

- The `resolveVariables` property in hook options has been changed from `boolean` to `readonly SceneNode['boundVariables'][] | 'all'`, meaning you can choose which variables the hook will resolve and add to a node before passing it to the plugin UI (similarly to `resolveProperties`).